### PR TITLE
Display view weekday as string, not number

### DIFF
--- a/Part3/view.sql
+++ b/Part3/view.sql
@@ -8,7 +8,7 @@ CREATE VIEW Vendas(ean, cat, ano, trimestre, mes, dia_mes, dia_semana, distrito,
 		EXTRACT(QUARTER FROM er.instante),
 		EXTRACT(MONTH FROM er.instante),
 		EXTRACT(DAY FROM er.instante),
-		EXTRACT(DOW FROM er.instante),
+		TO_CHAR(er.instante, 'Day'),
 		pr.distrito,
 		pr.concelho,
 		er.unidades


### PR DESCRIPTION
Show `Sunday` instead of `0`, etc.

Requested by professors.

**If this is ever reverted, use `ISODOW` instead of `DOW` -- professors asked that, if showing a number, `0` means `Monday`, not `Sunday`**