### PR TITLE
Fix query 1

### DIFF
--- a/Part3/queries.sql
+++ b/Part3/queries.sql
@@ -4,7 +4,7 @@ SELECT name
   NATURAL JOIN responsavel_por 
   GROUP BY tin 
   HAVING COUNT(tin) >= ALL (
-    SELECT COUNT(tin) 
+    SELECT COUNT(DISTINCT nome_cat)
     FROM responsavel_por 
     GROUP BY tin
 );


### PR DESCRIPTION
Only count distinct categories a retailer is responsible for.